### PR TITLE
These fixed the on-liner installation for me in AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ Get this file into the /root directory on the server. Just leave it as a zip fil
 3. Execute the following command:
 
 ```
-apt install git -y && git clone https://github.com/calr0x/OT-KwallaBetaInstalla.git && cd OT-KwallaBetaInstalla && ./installer.sh
+sudo apt install git -y && git clone https://github.com/calr0x/OT-KwallaBetaInstalla.git && cd OT-KwallaBetaInstalla && ./installer.sh
 ```

--- a/installer.sh
+++ b/installer.sh
@@ -305,7 +305,7 @@ else
     echo -e "${GREEN}SUCCESS${NC}"
 fi
 
-cd ot-node
+cd ~/ot-node
 
 echo -n "Executing git checkout: "
 


### PR DESCRIPTION
> node/npm install fails because of the directory path. When directory switching is like this ~/ it succeeds 
> I found node installation (packages) permission problem even if I was root. sudo solved that.